### PR TITLE
feat(grafana): add support for subpath routing and enable anonymous access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,12 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: "admin"
       GF_SECURITY_ADMIN_PASSWORD: "admin"
+      # ---------------------------------------------------------
+      # 2️⃣ Tell Grafana it lives under /grafana/
+      # ---------------------------------------------------------
+      GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s/grafana/"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
     volumes:
       - grafana-data:/var/lib/grafana
       # ⚠️ DO NOT MOUNT grafana.ini (latest versions break!)


### PR DESCRIPTION
- Configure Grafana server to serve from /grafana subpath
- Set appropriate root URL to maintain proper path in requests
- Enable anonymous access for testing/development environments

fixes: grafana-path-resolution-issue in Nginx

Assosciated artefact: [Add new upstream services to Nginx configuration](https://tvb-projects.atlassian.net/browse/VT-221)